### PR TITLE
Tap14 - Round 2, seven years in the making

### DIFF
--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -174,7 +174,7 @@ other way, rendering the output unreliable.
 The Plan lists the range of test point IDs that are expected in the TAP
 stream.  It can also optionally contain a comment/reason prefixed by a `#`.
 
-It's basic grammar is:
+Its basic grammar is:
 
 ```ebnf
 Plan := "1.." Number ("" | "# " Reason)

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -457,7 +457,8 @@ recognized, but cannot be set for some reason.
 ### Blank Lines
 
 For the purposes of this specification, a "blank" line is any line
-consisting exclusively of zero or more whitespace characters.
+consisting exclusively of zero or more whitespace characters (ie,
+`/^[ \t]+$/`).
 
 Blank lines within YAML blocks _must_ be preserved as part of the YAML
 document, because line breaks have semantic meaning in YAML documents.  For

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -511,7 +511,7 @@ A Harness _may_ silently ignore invalid TAP lines, pass them through to its
 own stderr or stdout, or report them in some other fashion.  However, it
 _should not_ treat invalid TAP lines as a test failure by default.
 
-## EXAMPLES
+## Examples
 
 All names, places, and events depicted in any example are wholly fictitious
 and bear no resemblance to, connection with, or relation to any real

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -3,14 +3,6 @@ layout: default
 title: TAP 14 specification
 ---
 
-# Status: DRAFT
-
-This is a draft document pending further editing and ratification by no
-fewer than 3 widely used TAP implementations in 3 different language
-communities.
-
-This section will likely be removed prior to ratification.
-
 ## Goals of This Specification
 
 * Document the observed behavior of widely used TAP implementations.

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -3,7 +3,7 @@ layout: default
 title: TAP 14 specification
 ---
 
-# STATUS: DRAFT
+# Status: DRAFT
 
 This is a draft document pending further editing and ratification by no
 fewer than 3 widely used TAP implementations in 3 different language
@@ -333,7 +333,7 @@ To summarize:
 - Directive (only when necessary)
 
 
-#### DIRECTIVES
+#### Directives
 
 Directives are special notes that follow a `#` on the Test Point line. Only
 two are currently defined: `TODO` and `SKIP`.
@@ -667,12 +667,12 @@ ok - board has 7 tiles + starter tile
 1..9
 ```
 
-## BUGS
+## Bugs
 
 Feature requests and bug reports should be [raised on
 GitHub.](https://github.com/TestAnything/Specification/issues/new)
 
-## AUTHORS
+## Authors
 
 The TAP 14 Specification is authored by [Isaac Z.
 Schlueter](https://github.com/isaacs), as a result of much discussion on
@@ -685,7 +685,7 @@ considerable input, encouragement, feedback, and suggestions from:
 * [Bruno P. Kinoshita](https://github.com/kinow)
 * [Chad Granum](https://github.com/exodist)
 
-## ACKNOWLEDGEMENTS
+## Acknowledgements
 
 The TAP 13 Specification was written by Andy Armstrong with help and
 contributions from Pete Krawczyk, Paul Johnson, Ian Langworth and Nik
@@ -696,7 +696,7 @@ The basis for the TAP format was created by Larry Wall in the original test
 script for Perl 1. Tim Bunce and Andreas Koenig developed it further with
 their modifications to Test::Harness.
 
-## COPYRIGHT
+## Copyright
 
 Copyright 2015-2022 by Isaac Z. Schlueter <i@izs.me> and Contributors.
 

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -3,6 +3,22 @@ layout: default
 title: TAP 14 specification
 ---
 
+# STATUS: DRAFT
+
+This is a draft document pending further editing and ratification by no
+fewer than 3 widely used TAP implementations in 3 different language
+communities.
+
+This section will likely be removed prior to ratification.
+
+## GOALS OF THIS SPECIFICATION
+
+* Document the observed behavior of widely used TAP implementations.
+* Add no features that are not already in wide usage across multiple
+  implementations.
+* Explicitly allow what is already allowed, deny what is already denied.
+* Provide updated and clearer guidance for new TAP implementations.
+
 # NAME
 
 TAP14 - The Test Anything Protocol v14
@@ -27,7 +43,7 @@ TAP14's general grammar is:
 ```ebnf
 TAPDocument := Version Plan Body | Version Body Plan
 Version     := "TAP version 14\n"
-Plan        := "1.." (Number) (" # " Reason)? "\n"
+Plan        := (Number) ".." (Number) (" # " Reason)? "\n"
 Body        := (TestPoint | BailOut | Pragma | Comment | Anything | Empty)*
 TestPoint   := ("not ")? "ok" (" " Number)? ((" -")? (" " Description) )? "\n" (YamlBlock)?
 YamlBlock   := "  ---\n" (YamlLine)* "  ...\n"

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -330,8 +330,10 @@ To summarize:
 #### DIRECTIVES
 
 Directives are special notes that follow a `#` on the Test Point line. Only
-two are currently defined: `TODO` and `SKIP`. These two keywords are not
-case-sensitive.
+two are currently defined: `TODO` and `SKIP`.
+
+Directives are not case sensitive.  That is, Harnesses _must_ treat `#
+SKIP`, `# skip`, and `# SkIp` identically.
 
 Harnesses _may_ support additional platform-specific directives.  Future
 versions of this specification _may_ codify additional directives with

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -786,6 +786,9 @@ considerable input, encouragement, feedback, and suggestions from:
 
 ## Acknowledgements
 
+Special thanks to [Jonathan Kingston](https://github.com/jonathanKingston)
+for his efforts to keep TAP flourishing and bring implementors together.
+
 The TAP 13 Specification was written by Andy Armstrong with help and
 contributions from Pete Krawczyk, Paul Johnson, Ian Langworth and Nik
 Clayton, based on the original TAP documentation by Andy Lester, based on

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -963,7 +963,7 @@ failure, because the `strict` Pragma setting at the parent level was false.
    until a matching test point (same name, or no name in either) at parent
    level is found, treating any other un-indented lines as non-TAP, and
    fail the test if a matching test point is not found.
-9. If subtest comment is not provided, Harnesses _must_ treat the next Test
+9. If Subtest Comment is not provided, Harnesses _must_ treat the next Test
    Point at the parent level as the end of the subtest, and treat any
    intervening lines indented less than the subtest level as non-TAP.
 10. Harnesses _should_ treat unterminated Subtests as non-TAP.

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -336,7 +336,8 @@ description reported to a user.
 #### Directive
 
 Directives are special notes that follow the first unescaped `#` on the
-Test Point line.  Only two are currently defined: `TODO` and `SKIP`.
+Test Point line which is preceded by whitespace.  Only two are currently
+defined: `TODO` and `SKIP`.
 
 Directives are not case sensitive.  That is, Harnesses _must_ treat `#
 SKIP`, `# skip`, and `# SkIp` identically.
@@ -352,19 +353,23 @@ in the Test Point description.
 Note that escaped `#` characters are not to be treated as delimiters for
 Directives.  See "Escaping" below.
 
-##### Backwards Compatibility Note
+##### Backwards Compatibility and Parsing Notes
 
 For backwards compatibility with earlier incarnations of TAP, Harnesses
 _must_ accept additional non-whitespace characters following the the
-literal strings `"# SKIP"` or `"# TODO"`.  Everything after
-`(TODO|SKIP)\S*\s+` is the reason.  For example, this is supported, and
-shows a test with 2 `skip` tests: one with no reason given, and the other
-with an explanation.
+literal strings `"SKIP"` or `"TODO"`.  Everything after `(TODO|SKIP)\S*\s+`
+is the reason.  For example, this is supported, and shows a test with 2
+`skip` tests: one with no reason given, and the other with an explanation.
 
 ```tap
 TAP version 14
 1..2
+
+# skip: true
 ok 1 - do it later # Skipped
+
+# skip: true
+# skip reason: "only run on windows"
 ok 2 - works on windows # Skipped: only run on windows
 ```
 
@@ -377,9 +382,29 @@ may drop support for `\S*` characters following directive names.
 Thus, the regular expression for directives is:
 
 ```
-/#\s+(SKIP|TODO)\S*\s+([^\n]*)/
+/\s+#\s*(SKIP|TODO)\S*\s+([^\n]*)/
 directive type = $1
 reason = $2
+```
+
+More examples of parsing directives:
+
+```tap
+TAP version 14
+
+# skip: true
+# skip reason: "this test is skipped"
+# description: ""
+ok 1 #skip this test is skipped
+
+# skip: false
+# description: "not skipped: https://example.com/page.html\#skip is a url"
+ok 2 not skipped: https://example.com/page.html#skip is a url
+
+# skip: true
+# skip reason: "case insensitive, so this is skipped"
+# description: ""
+ok 3 - #SkIp case insensitive, so this is skipped
 ```
 
 ##### `TODO` tests

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -793,8 +793,9 @@ not_ include a Version, if TAP13 Harness compatibility is desirable.
 
 ### Bare Subtests
 
-In its simplest form, a Subtest is introduced by a 4-space indented Test
-Point, Version, Plan or Pragma line.
+In its simplest form, a Subtest is introduced by a 4-space indented valid
+TAP line.  That is, a Test Point, Version, Plan, or (if Pragmas are
+supported) Pragma, prefixed by 4 space characters.
 
 For example:
 

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -352,10 +352,40 @@ in the Test Point description.
 Note that escaped `#` characters are not to be treated as delimiters for
 Directives.  See "Escaping" below.
 
+##### Backwards Compatibility Note
+
+For backwards compatibility with earlier incarnations of TAP, Harnesses
+_must_ accept additional non-whitespace characters following the the
+literal strings `"# SKIP"` or `"# TODO"`.  Everything after
+`(TODO|SKIP)\S*\s+` is the reason.  For example, this is supported, and
+shows a test with 2 `skip` tests: one with no reason given, and the other
+with an explanation.
+
+```tap
+TAP version 14
+1..2
+ok 1 - do it later # Skipped
+ok 2 - works on windows # Skipped: only run on windows
+```
+
+For broad compatibility with as many harnesses as possible, as well as
+future-proofing their output, Producers _should_ always report `SKIP` and
+`TODO` tests using only the directive names ("SKIP" or "TODO"), optionally
+followed by a space and a reason.  Future versions of this specification
+may drop support for `\S*` characters following directive names.
+
+Thus, the regular expression for directives is:
+
+```
+/#\s+(SKIP|TODO)\S*\s+([^\n]*)/
+directive type = $1
+reason = $2
+```
+
 ##### `TODO` tests
 
 If the directive starts with `# TODO`, the test is counted as a todo test,
-and the text after `TODO` is the explanation.
+and any text after `TODO\S*\s+` is the explanation.
 
 ```tap
 not ok 14 # TODO bend space and time
@@ -378,7 +408,7 @@ needing work, if that is appropriate for their use case.
 ##### `SKIP` tests
 
 If the directive starts with `# SKIP`, the test is counted as a skipped
-test, and the text after `SKIP` is the explanation.
+test, and the text after `SKIP\S*\s+` is the explanation.
 
 ```tap
 ok 14 - mung the gums # SKIP leave gums unmunged for now

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -468,6 +468,9 @@ if they would normally treat invalid TAP as a test failure.  Harnesses
 _may_ warn if a Pragma is unrecognized, or fail if the named pragma is
 recognized, but cannot be set for some reason.
 
+Pragmas _must not_ include comments, directives, or other characters other
+than those specified above.
+
 ### Blank Lines
 
 For the purposes of this specification, a "blank" line is any line

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -29,7 +29,7 @@ TAP, the Test Anything Protocol, is a simple text-based interface between
 testing modules a test harness. TAP started life as part of the test
 harness for Perl but now has implementations in C/C++, Python, PHP, Perl,
 JavaScript, and probably others by the time you read this.  This document
-describes version 14 of TAP. Go to TAP to read about previous versions.
+describes version 14 of TAP.
 
 The key words _must_, _must not_, _required_, _shall_, _shall not_,
 _should_, _should not_, _recommended_, _may_, and _optional_ in this

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -243,9 +243,10 @@ point comprises the following elements:
     ok 5
     ```
 
-    This test output is _not_ valid TAP:
+    This test output is _not_ a successful test run:
 
     ```tap
+    TAP version 13
     1..6
     not ok
     ok
@@ -254,7 +255,9 @@ point comprises the following elements:
     ok
     ```
 
-    has five tests. The sixth is missing. Test::Harness will generate
+    Five tests are shown, but the plan indicated that there would be 6.
+    Furthermore, tests 1 and 3 are explicitly failing.  Perl's
+    `Test::Harness` will report:
 
     ```
     FAILED tests 1, 3, 6
@@ -264,7 +267,7 @@ point comprises the following elements:
     Test Points _may_ be output in any order, but any Test Point ID
     provided _must_ be within the range described by the Plan.
 
-    This is valid TAP:
+    This is valid TAP and a successful test run:
 
     ```tap
     TAP version 14
@@ -274,7 +277,8 @@ point comprises the following elements:
     ok 1
     ```
 
-    This is not valid TAP:
+    This is not a successful test run. Even though there are 3 Test Points,
+    the Test Point ID 4 is outside the stated Plan range.
 
     ```tap
     TAP version 14

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -263,7 +263,7 @@ ok 5
 This test output is _not_ a successful test run:
 
 ```tap
-TAP version 13
+TAP version 14
 1..6
 not ok
 ok
@@ -380,7 +380,7 @@ necessary for backwards compatibility with existing TAP producers.
 For example:
 
 ```tap
-TAP version 13
+TAP version 14
 
 # MUST be treated as a SKIP test
 ok 1 - must be skipped test # SKIP
@@ -553,7 +553,7 @@ The structure of a Pragma line is:
 For example:
 
 ```tap
-TAP version 13
+TAP version 14
 # tell the parser to bail out on any failures from now on
 pragma +bail
 

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -426,7 +426,8 @@ The structure of a Pragma line is:
 
 - `"pragma "`
 - `+` (true) or `-` (false)
-- key: The name of the field being enabled or disabled.
+- key: The name of the field being enabled or disabled.  ASCII alphanumeric
+  characters, `_`, and `-` are allowed.
 
 For example:
 
@@ -436,7 +437,7 @@ TAP version 13
 pragma +bail
 
 # tell the parser to execute in strict mode, treating any invalid TAP
-# as a test failure.
+# line as a test failure.
 pragma +strict
 
 # turn off a feature we don't want to be active right now
@@ -446,9 +447,12 @@ pragma -bail
 The meaning and availability of keys that may be set by Pragmas are
 implementation-specific.
 
-Harnesses _must not_ treat unrecognized Pragma keys as a test failure.
-However, they _may_ warn if a Pragma is unrecognized, or fail if the
-named flag cannot be set for some reason.
+Harnesses _may_ choose to respond to Pragma lines, or ignore them.
+
+Harnesses _must not_ treat unrecognized Pragma keys as a test failure, even
+if they would normally treat invalid TAP as a test failure.  Harnesses
+_may_ warn if a Pragma is unrecognized, or fail if the named pragma is
+recognized, but cannot be set for some reason.
 
 ### Blank Lines
 

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -646,27 +646,38 @@ ok - board has 7 tiles + starter tile
 ## BUGS
 
 Feature requests and bug reports should be [raised on
-GitHub.](https://github.com/TestAnything/testanything.github.io/issues/new)
+GitHub.](https://github.com/TestAnything/Specification/issues/new)
 
 ## AUTHORS
 
-The original TAP documentation (of which this is a hacked about version)
-was written by Andy Lester, based on the original Test::Harness
-documentation by Michael Schwern.  This version was written by Andy
-Armstrong.
+The TAP 14 Specification is authored by [Isaac Z.
+Schlueter](https://github.com/isaacs), as a result of much discussion on
+the [TestAnything
+Specification](https://github.com/TestAnything/Specification) project, with
+considerable input, encouragement, feedback, and suggestions from:
+
+* [Matt Layman](https://github.com/mblayman)
+* [Leon Timmermans](https://github.com/Leont)
+* [Bruno P. Kinoshita](https://github.com/kinow)
+* [Chad Granum](https://github.com/exodist)
 
 ## ACKNOWLEDGEMENTS
 
-Thanks to Pete Krawczyk, Paul Johnson, Ian Langworth and Nik Clayton for
-help and contributions on this document.  The basis for the TAP format was
-created by Larry Wall in the original test script for Perl 1. Tim Bunce and
-Andreas Koenig developed it further with their modifications to
-Test::Harness.
+The TAP 13 Specification was written by Andy Armstrong with help and
+contributions from Pete Krawczyk, Paul Johnson, Ian Langworth and Nik
+Clayton, based on the original TAP documentation by Andy Lester, based on
+the original Test::Harness documentation by Michael Schwern.
+
+The basis for the TAP format was created by Larry Wall in the original test
+script for Perl 1. Tim Bunce and Andreas Koenig developed it further with
+their modifications to Test::Harness.
 
 ## COPYRIGHT
 
+Copyright 2015-2022 by Isaac Z. Schlueter <i@izs.me> and Contributors.
+
 Copyright 2003-2007 by Michael G Schwern <schwern@pobox.com>, Andy Lester
-<andy@petdance.com>, Andy Armstrong <andy@hexten.net>.  This program is
-free software; you can redistribute it and/or modify it under the same
-terms as Perl itself.  See
-[http://www.perl.com/perl/misc/artistic.html](http://www.perl.com/perl/misc/artistic.html).
+<andy@petdance.com>, Andy Armstrong <andy@hexten.net>.
+
+This specification is released under the [Artistic License
+2.0](https://opensource.org/licenses/Artistic-2.0)

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -1,0 +1,473 @@
+---
+layout: default
+title: TAP 13 specification
+---
+
+# NAME
+
+TAP13 - The Test Anything Protocol v13
+
+## SYNOPSIS
+
+TAP, the Test Anything Protocol, is a simple text-based interface between
+testing modules a test harness. TAP started life as part of the test
+harness for Perl but now has implementations in C/C++, Python, PHP, Perl,
+JavaScript, and probably others by the time you read this.  This document
+describes version 13 of TAP. Go to TAP to read about previous versions.
+
+## THE TAP13 FORMAT
+
+TAP13's general format is:
+
+```
+TAP version 13
+1..N
+ok 1 Description # Directive
+# Diagnostic
+  ---
+  message: 'Failure message'
+  severity: fail
+  data:
+    got:
+      - 1
+      - 3
+      - 2
+    expect:
+      - 1
+      - 2
+      - 3
+  ...
+ok 47 Description
+ok 48 Description
+more tests....
+```
+
+For example, a test file's output might look like:
+
+```
+TAP version 13
+1..4
+ok 1 - Input file opened
+not ok 2 - First line of the input valid
+  ---
+  message: 'First line invalid'
+  severity: fail
+  data:
+    got: 'Flirble'
+    expect: 'Fnible'
+  ...
+ok 3 - Read the rest of the file
+not ok 4 - Summarized correctly # TODO Not written yet
+  ---
+  message: "Can't make summary yet"
+  severity: todo
+  ...
+```
+
+## HARNESS BEHAVIOR
+
+In this document, the "harness" is any program analyzing TAP output.
+Typically this will be Perl's runtests program, or the underlying
+TAP::Harness-runtests> method.  A harness must only read TAP output from
+standard output and not from standard error. Lines written to standard
+output matching `/^(not )?ok\b/` must be interpreted as test lines. After a
+test line a block of lines starting with '---' and ending with '...' will
+be interpreted as an inline YAML document providing extended diagnostic
+information about the preceding test. All other lines must not be
+considered test output.
+
+## TESTS LINES AND THE PLAN
+
+### The version
+
+To indicate that this is TAP13 the first line must be
+
+```
+TAP version 13
+```
+
+### The plan
+
+The plan tells how many tests will be run, or how many tests have run. It's
+a check that the test file hasn't stopped prematurely. It must appear once,
+whether at the beginning or end of the output.  The plan is usually the
+second line of TAP output right after the version line, and it specifies
+how many test points are to follow. For example,
+
+```
+1..10
+```
+
+means you plan on running 10 tests. This is a safeguard in case your test
+file dies silently in the middle of its run. The plan is optional but if
+there is a plan before the test points it must be the first non-diagnostic
+line output by the test file.  In certain instances a test file may not
+know how many test points it will ultimately be running. In this case the
+plan can be the last non-diagnostic line in the output.  The plan cannot
+appear in the middle of the output, nor can it appear more than once.
+
+### The test line
+
+The core of TAP is the test line. A test file prints one test line test
+point executed. There must be at least one test line in TAP output. Each
+test line comprises the following elements:
+
+-    ok or not ok
+
+This tells whether the test point passed or failed. It must be at the
+beginning of the line. `/^not ok/` indicates a failed test point. `/^ok/`
+is a successful test point. This is the only mandatory part of the line.
+Note that unlike the Directives below, ok and not ok are case-sensitive.
+
+-    Test number
+
+TAP expects the ok or not ok to be followed by a test point number. If
+there is no number the harness must maintain its own counter until the
+script supplies test numbers again. So the following test output
+
+```
+1..6
+not ok
+ok
+not ok
+ok
+ok
+```
+
+has five tests. The sixth is missing. Test::Harness will generate
+
+```
+FAILED tests 1, 3, 6
+Failed 3/6 tests, 50.00% okay
+```
+
+-    Description Any text after the test number but before a # is the
+     description of the test point.
+
+```
+ok 42 this is the description of the test
+```
+
+Descriptions should not begin with a digit so that they are not confused
+with the test point number.  The harness may do whatever it wants with the
+description.
+
+-    Directive The test point may include a directive, following a hash on
+     the test line. There are currently two directives allowed: TODO and
+     SKIP. These are discussed below.
+
+To summarize:
+
+-    ok/not ok (required)
+-    Test number (recommended)
+-    Description (recommended)
+-    Directive (only when necessary)
+
+### YAML blocks
+
+If the test line is immediately followed by an indented block beginning
+with `/^\s+---/` and ending with `/^\s+.../` that block will be interpreted
+as an inline YAML document. The YAML encodes a data structure that provides
+more detailed information about the preceding test.  The YAML document is
+indented to make it visually distinct from the surrounding test results and
+to make it easier for the parser to recover if the trailing '...'
+terminator is missing.  For example:
+
+```
+not ok 3 Resolve address
+ ---
+ message: "Failed with error 'hostname peebles.example.com not found'"
+ severity: fail
+ data:
+   got:
+     hostname: 'peebles.example.com'
+     address: ~
+   expected:
+     hostname: 'peebles.example.com'
+     address: '85.193.201.85'
+ ...
+```
+
+For a harness written in Perl the corresponding data structure would look
+like this:
+
+```
+$diagnostic = {
+    'message'  => "Failed with error 'hostname peebles.example.com not found'",
+    'severity' => 'fail',
+    'data' => {
+        'got' => {
+            'hostname' => 'peebles.example.com',
+            'address'  => undef,
+        },
+        'expected' => {
+            'hostname' => 'peebles.example.com',
+            'address'  => '85.193.201.85',
+        }
+    },
+};
+```
+
+Currently (2007/03/17) the format of the data structure represented by a
+YAML block has not been standardized. It is likely that whatever schema
+emerges will be able to capture the kind of forensic information about a
+test's execution seen in the example above.
+
+## DIRECTIVES
+
+Directives are special notes that follow a # on the test line. Only two are
+currently defined: TODO and SKIP. Note that these two keywords are not
+case-sensitive.
+
+### TODO tests
+
+If the directive starts with # TODO, the test is counted as a todo test,
+and the text after TODO is the explanation.
+
+```
+not ok 13 # TODO bend space and time
+```
+
+Note that if the TODO has an explanation it must be separated from TODO by
+a space.  These tests represent a feature to be implemented or a bug to be
+fixed and act as something of an executable "things to do" list. They are
+not expected to succeed. Should a todo test point begin succeeding, the
+harness should report it as a bonus. This indicates that whatever you were
+supposed to do has been done and you should promote this to a normal test
+point.
+
+### Skipping tests
+
+If the directive starts with # SKIP, the test is counted as having been
+skipped. If the whole test file succeeds, the count of skipped tests is
+included in the generated output. The harness should report the text after
+# SKIP\S*\s+ as a reason for skipping.
+
+```
+ok 23 # skip Insufficient flogiston pressure.
+```
+
+Similarly, one can include an explanation in a plan line, emitted if the
+test file is skipped completely:
+
+```
+1..0 # Skipped: WWW::Mechanize not installed
+```
+
+## OTHER LINES
+
+### Bail out!
+
+As an emergency measure a test script can decide that further tests are
+useless (e.g. missing dependencies) and testing should stop immediately. In
+that case the test script prints the magic words
+
+```
+Bail out!
+```
+
+to standard output. Any message after these words must be displayed by the
+interpreter as the reason why testing must be stopped, as in
+
+```
+Bail out! MySQL is not running.
+```
+
+### Diagnostics
+
+Additional information may be put into the testing output on separate
+lines. Diagnostic lines should begin with a #, which the harness must
+ignore, at least as far as analyzing the test results. The harness is free,
+however, to display the diagnostics.  TAP13's YAML blocks are intended to
+replace diagnostics for most purposes but TAP13 consumers should maintain
+backwards compatibility by supporting them.
+
+### Anything else
+
+Any output that is not a version, a plan, a test line, a YAML block, a
+diagnostic or a bail out is incorrect. How a harness handles the incorrect
+line is undefined.  Test::Harness silently ignores incorrect lines, but
+will become more stringent in the future.  TAP::Harness reports TAP syntax
+errors at the end of a test run.
+
+## EXAMPLES
+
+All names, places, and events depicted in any example are wholly fictitious
+and bear no resemblance to, connection with, or relation to any real
+entity. Any such similarity is purely coincidental, unintentional, and
+unintended.
+
+### Common with explanation
+
+The following TAP listing declares that six tests follow as well as
+provides handy feedback as to what the test is about to do. All six tests
+pass.
+
+```
+TAP version 13
+1..6
+#
+# Create a new Board and Tile, then place
+# the Tile onto the board.
+#
+ok 1 - The object isa Board
+ok 2 - Board size is zero
+ok 3 - The object isa Tile
+ok 4 - Get possible places to put the Tile
+ok 5 - Placing the tile produces no error
+ok 6 - Board size is 1
+```
+
+### Unknown amount and failures
+
+This hypothetical test program ensures that a handful of servers are online
+and network-accessible. Because it retrieves the hypothetical servers from
+a database, it doesn't know exactly how many servers it will need to ping.
+Thus, the test count is declared at the bottom after all the test points
+have run. Also, two of the tests fail. The YAML block following each
+failure gives additional information about the failure that may be
+displayed by the harness.
+
+```
+TAP version 13
+ok 1 - retrieving servers from the database
+# need to ping 6 servers
+ok 2 - pinged diamond
+ok 3 - pinged ruby
+not ok 4 - pinged saphire
+  ---
+  message: 'hostname "saphire" unknown'
+  severity: fail
+  ...
+ok 5 - pinged onyx
+not ok 6 - pinged quartz
+  ---
+  message: 'timeout'
+  severity: fail
+  ...
+ok 7 - pinged gold
+1..7
+```
+
+### Giving up
+
+This listing reports that a pile of tests are going to be run. However, the
+first test fails, reportedly because a connection to the database could not
+be established. The program decided that continuing was pointless and
+exited.
+
+```
+TAP version 13
+1..573
+not ok 1 - database handle
+Bail out! Couldn't connect to database.
+```
+
+### Skipping a few
+
+The following listing plans on running 5 tests. However, our program
+decided to not run tests 2 thru 5 at all. To properly report this, the
+tests are marked as being skipped.
+
+```
+TAP version 13
+1..5
+ok 1 - approved operating system
+# $^0 is solaris
+ok 2 - # SKIP no /sys directory
+ok 3 - # SKIP no /sys directory
+ok 4 - # SKIP no /sys directory
+ok 5 - # SKIP no /sys directory
+```
+
+### Skipping everything
+
+This listing shows that the entire listing is a skip. No tests were run.
+
+```
+TAP version 13
+1..0 # skip because English-to-French translator isn't installed
+```
+
+## Got spare tuits?
+
+The following example reports that four tests are run and the last two
+tests failed. However, because the failing tests are marked as things to do
+later, they are considered successes. Thus, a harness should report this
+entire listing as a success.
+
+```
+TAP version 13
+1..4
+ok 1 - Creating test program
+ok 2 - Test program runs, no error
+not ok 3 - infinite loop # TODO halting problem unsolved
+not ok 4 - infinite loop 2 # TODO halting problem unsolved
+```
+
+## Creative liberties
+
+This listing shows an alternate output where the test numbers aren't
+provided. The test also reports the state of a ficticious board game as a
+YAML block. Finally, the test count is reported at the end.
+
+```
+TAP version 13
+ok - created Board
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+  ---
+  message: "Board layout"
+  severity: comment
+  dump:
+     board:
+       - '      16G         05C        '
+       - '      G N C       C C G      '
+       - '        G           C  +     '
+       - '10C   01G         03C        '
+       - 'R N G G A G       C C C      '
+       - '  R     G           C  +     '
+       - '      01G   17C   00C        '
+       - '      G A G G N R R N R      '
+       - '        G     R     G        '
+  ...
+ok - board has 7 tiles + starter tile
+1..9
+```
+
+## BUGS
+
+Feature requests and bug reports should be [raised on
+GitHub.](https://github.com/TestAnything/testanything.github.io/issues/new)
+
+## AUTHORS
+
+The original TAP documentation (of which this is a hacked about version)
+was written by Andy Lester, based on the original Test::Harness
+documentation by Michael Schwern.  This version was written by Andy
+Armstrong.
+
+## ACKNOWLEDGEMENTS
+
+Thanks to Pete Krawczyk, Paul Johnson, Ian Langworth and Nik Clayton for
+help and contributions on this document.  The basis for the TAP format was
+created by Larry Wall in the original test script for Perl 1. Tim Bunce and
+Andreas Koenig developed it further with their modifications to
+Test::Harness.
+
+## COPYRIGHT
+
+Copyright 2003-2007 by Michael G Schwern <schwern@pobox.com>, Andy Lester
+<andy@petdance.com>, Andy Armstrong <andy@hexten.net>.  This program is
+free software; you can redistribute it and/or modify it under the same
+terms as Perl itself.  See
+[http://www.perl.com/perl/misc/artistic.html](http://www.perl.com/perl/misc/artistic.html).
+
+## TODO
+
+Define the exit code of the process.

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -366,8 +366,8 @@ needing work, if that is appropriate for their use case.
 
 ##### SKIP tests
 
-If the directive starts with `# SKIP`, the test is counted as a todo test,
-and the text after `SKIP` is the explanation.
+If the directive starts with `# SKIP`, the test is counted as a skipped
+test, and the text after `SKIP` is the explanation.
 
 ```tap
 ok 14 - mung the gums # SKIP leave gums unmunged for now

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -128,6 +128,12 @@ analyze the recorded output of past test runs and provide data about them.
 
 ## Document Structure
 
+TAP14 producers _must_ encode TAP data using the UTF-8 encoding.
+
+Harnesses _should_ interpret all TAP streams using UTF-8.  Harnesses _may_
+provide a mechanism for using other encodings explicitly, if needed for
+backwards compatibility.
+
 ### Version
 
 To indicate that this is TAP14 the first line _must_ be

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -1,11 +1,11 @@
 ---
 layout: default
-title: TAP 13 specification
+title: TAP 14 specification
 ---
 
 # NAME
 
-TAP13 - The Test Anything Protocol v13
+TAP14 - The Test Anything Protocol v14
 
 ## SYNOPSIS
 
@@ -13,14 +13,14 @@ TAP, the Test Anything Protocol, is a simple text-based interface between
 testing modules a test harness. TAP started life as part of the test
 harness for Perl but now has implementations in C/C++, Python, PHP, Perl,
 JavaScript, and probably others by the time you read this.  This document
-describes version 13 of TAP. Go to TAP to read about previous versions.
+describes version 14 of TAP. Go to TAP to read about previous versions.
 
-## THE TAP13 FORMAT
+## THE TAP14 FORMAT
 
-TAP13's general format is:
+TAP14's general format is:
 
 ```
-TAP version 13
+TAP version 14
 1..N
 ok 1 Description # Directive
 # Diagnostic
@@ -45,7 +45,7 @@ more tests....
 For example, a test file's output might look like:
 
 ```
-TAP version 13
+TAP version 14
 1..4
 ok 1 - Input file opened
 not ok 2 - First line of the input valid
@@ -80,11 +80,16 @@ considered test output.
 
 ### The version
 
-To indicate that this is TAP13 the first line must be
+To indicate that this is TAP14 the first line must be
 
 ```
-TAP version 13
+TAP version 14
 ```
+
+Parsers _may_ interpret ostensibly
+[TAP13](https://testanything.org/tap-version-13-specification.html) streams
+as TAP14, as this specification is compatible with observed behavior of
+existing TAP13 consumers and producers.
 
 ### The plan
 
@@ -225,7 +230,7 @@ If the directive starts with # TODO, the test is counted as a todo test,
 and the text after TODO is the explanation.
 
 ```
-not ok 13 # TODO bend space and time
+not ok 14 # TODO bend space and time
 ```
 
 Note that if the TODO has an explanation it must be separated from TODO by
@@ -278,8 +283,8 @@ Bail out! MySQL is not running.
 Additional information may be put into the testing output on separate
 lines. Diagnostic lines should begin with a #, which the harness must
 ignore, at least as far as analyzing the test results. The harness is free,
-however, to display the diagnostics.  TAP13's YAML blocks are intended to
-replace diagnostics for most purposes but TAP13 consumers should maintain
+however, to display the diagnostics.  TAP14's YAML blocks are intended to
+replace diagnostics for most purposes but TAP14 consumers should maintain
 backwards compatibility by supporting them.
 
 ### Anything else
@@ -304,7 +309,7 @@ provides handy feedback as to what the test is about to do. All six tests
 pass.
 
 ```
-TAP version 13
+TAP version 14
 1..6
 #
 # Create a new Board and Tile, then place
@@ -329,7 +334,7 @@ failure gives additional information about the failure that may be
 displayed by the harness.
 
 ```
-TAP version 13
+TAP version 14
 ok 1 - retrieving servers from the database
 # need to ping 6 servers
 ok 2 - pinged diamond
@@ -357,7 +362,7 @@ be established. The program decided that continuing was pointless and
 exited.
 
 ```
-TAP version 13
+TAP version 14
 1..573
 not ok 1 - database handle
 Bail out! Couldn't connect to database.
@@ -370,7 +375,7 @@ decided to not run tests 2 thru 5 at all. To properly report this, the
 tests are marked as being skipped.
 
 ```
-TAP version 13
+TAP version 14
 1..5
 ok 1 - approved operating system
 # $^0 is solaris
@@ -385,7 +390,7 @@ ok 5 - # SKIP no /sys directory
 This listing shows that the entire listing is a skip. No tests were run.
 
 ```
-TAP version 13
+TAP version 14
 1..0 # skip because English-to-French translator isn't installed
 ```
 
@@ -397,7 +402,7 @@ later, they are considered successes. Thus, a harness should report this
 entire listing as a success.
 
 ```
-TAP version 13
+TAP version 14
 1..4
 ok 1 - Creating test program
 ok 2 - Test program runs, no error
@@ -412,7 +417,7 @@ provided. The test also reports the state of a ficticious board game as a
 YAML block. Finally, the test count is reported at the end.
 
 ```
-TAP version 13
+TAP version 14
 ok - created Board
 ok
 ok

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -312,6 +312,12 @@ Directives are special notes that follow a # on the Test Point line. Only
 two are currently defined: `TODO` and `SKIP`. These two keywords are not
 case-sensitive.
 
+Harnesses _may_ support additional platform-specific directives.  Future
+versions of this specification _may_ codify additional directives with
+defined semantics.
+
+Unrecognized directives _must_ be ignored, and treated as comments.
+
 ##### TODO tests
 
 If the directive starts with `# TODO`, the test is counted as a todo test,

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -168,16 +168,16 @@ The Plan specifies how many test points are to follow. For example,
 means that either 10 test points will follow, or 10 test points are
 believed to have been present in the stream already.
 
-This is a safeguard in case the test file dies silently in the middle of
-its run.
+This is a safeguard against test data being truncated or damaged in some
+other way, rendering the output unreliable.
 
 The Plan lists the range of test point IDs that are expected in the TAP
-stream.  It can also optionally contain a comment prefixed by a `#`.
+stream.  It can also optionally contain a comment/reason prefixed by a `#`.
 
 It's basic grammar is:
 
 ```ebnf
-Plan := Number ".." Number ("" | "# " Comment)
+Plan := "1.." Number ("" | "# " Reason)
 ```
 
 A plan line of `1..0` indicates that the test set was completely skipped;
@@ -190,10 +190,14 @@ skipping.
 1..0 # WWW::Mechanize not installed
 ```
 
-**Note**: Plan lines starting with a number other than `1` are deprecated,
-and _may_ be treated as invalid in a future version of this specification.
-At the present time (March 2022), most popular TAP generating utilities
-always start Plan lines at 1.
+Previous versions of TAP allowed plans to specify any two numbers, for
+example, `5..8` to indicate that test points with IDs between 5 and 8 would
+be run.  However, this is not widely supported.
+
+Thus, TAP14 producers _must_ output a Plan starting with `1`.  TAP14
+Harnesses _may_ allow plans starting with numbers other than 1, but if so,
+they _must_ treat any Test Point IDs outside the plan range as a test
+failure.
 
 ### Test Points
 

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -19,7 +19,7 @@ describes version 14 of TAP. Go to TAP to read about previous versions.
 
 TAP14's general format is:
 
-```
+```tap
 TAP version 14
 1..N
 ok 1 Description # Directive
@@ -44,7 +44,7 @@ more tests....
 
 For example, a test file's output might look like:
 
-```
+```tap
 TAP version 14
 1..4
 ok 1 - Input file opened
@@ -82,7 +82,7 @@ considered test output.
 
 To indicate that this is TAP14 the first line must be
 
-```
+```tap
 TAP version 14
 ```
 
@@ -99,7 +99,7 @@ whether at the beginning or end of the output.  The plan is usually the
 second line of TAP output right after the version line, and it specifies
 how many test points are to follow. For example,
 
-```
+```tap
 1..10
 ```
 
@@ -130,7 +130,7 @@ TAP expects the ok or not ok to be followed by a test point number. If
 there is no number the harness must maintain its own counter until the
 script supplies test numbers again. So the following test output
 
-```
+```tap
 1..6
 not ok
 ok
@@ -149,7 +149,7 @@ Failed 3/6 tests, 50.00% okay
 -    Description Any text after the test number but before a # is the
      description of the test point.
 
-```
+```tap
 ok 42 this is the description of the test
 ```
 
@@ -178,7 +178,7 @@ indented to make it visually distinct from the surrounding test results and
 to make it easier for the parser to recover if the trailing '...'
 terminator is missing.  For example:
 
-```
+```tap
 not ok 3 Resolve address
  ---
  message: "Failed with error 'hostname peebles.example.com not found'"
@@ -196,7 +196,7 @@ not ok 3 Resolve address
 For a harness written in Perl the corresponding data structure would look
 like this:
 
-```
+```perl
 $diagnostic = {
     'message'  => "Failed with error 'hostname peebles.example.com not found'",
     'severity' => 'fail',
@@ -229,7 +229,7 @@ case-sensitive.
 If the directive starts with # TODO, the test is counted as a todo test,
 and the text after TODO is the explanation.
 
-```
+```tap
 not ok 14 # TODO bend space and time
 ```
 
@@ -248,14 +248,14 @@ skipped. If the whole test file succeeds, the count of skipped tests is
 included in the generated output. The harness should report the text after
 # SKIP\S*\s+ as a reason for skipping.
 
-```
+```tap
 ok 23 # skip Insufficient flogiston pressure.
 ```
 
 Similarly, one can include an explanation in a plan line, emitted if the
 test file is skipped completely:
 
-```
+```tap
 1..0 # Skipped: WWW::Mechanize not installed
 ```
 
@@ -267,14 +267,14 @@ As an emergency measure a test script can decide that further tests are
 useless (e.g. missing dependencies) and testing should stop immediately. In
 that case the test script prints the magic words
 
-```
+```tap
 Bail out!
 ```
 
 to standard output. Any message after these words must be displayed by the
 interpreter as the reason why testing must be stopped, as in
 
-```
+```tap
 Bail out! MySQL is not running.
 ```
 
@@ -308,7 +308,7 @@ The following TAP listing declares that six tests follow as well as
 provides handy feedback as to what the test is about to do. All six tests
 pass.
 
-```
+```tap
 TAP version 14
 1..6
 #
@@ -333,7 +333,7 @@ have run. Also, two of the tests fail. The YAML block following each
 failure gives additional information about the failure that may be
 displayed by the harness.
 
-```
+```tap
 TAP version 14
 ok 1 - retrieving servers from the database
 # need to ping 6 servers
@@ -361,7 +361,7 @@ first test fails, reportedly because a connection to the database could not
 be established. The program decided that continuing was pointless and
 exited.
 
-```
+```tap
 TAP version 14
 1..573
 not ok 1 - database handle
@@ -374,7 +374,7 @@ The following listing plans on running 5 tests. However, our program
 decided to not run tests 2 thru 5 at all. To properly report this, the
 tests are marked as being skipped.
 
-```
+```tap
 TAP version 14
 1..5
 ok 1 - approved operating system
@@ -389,7 +389,7 @@ ok 5 - # SKIP no /sys directory
 
 This listing shows that the entire listing is a skip. No tests were run.
 
-```
+```tap
 TAP version 14
 1..0 # skip because English-to-French translator isn't installed
 ```
@@ -401,7 +401,7 @@ tests failed. However, because the failing tests are marked as things to do
 later, they are considered successes. Thus, a harness should report this
 entire listing as a success.
 
-```
+```tap
 TAP version 14
 1..4
 ok 1 - Creating test program
@@ -416,7 +416,7 @@ This listing shows an alternate output where the test numbers aren't
 provided. The test also reports the state of a ficticious board game as a
 YAML block. Finally, the test count is reported at the end.
 
-```
+```tap
 TAP version 14
 ok - created Board
 ok

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -789,11 +789,11 @@ considerable input, encouragement, feedback, and suggestions from:
 The TAP 13 Specification was written by Andy Armstrong with help and
 contributions from Pete Krawczyk, Paul Johnson, Ian Langworth and Nik
 Clayton, based on the original TAP documentation by Andy Lester, based on
-the original Test::Harness documentation by Michael Schwern.
+the original `Test::Harness` documentation by Michael Schwern.
 
 The basis for the TAP format was created by Larry Wall in the original test
 script for Perl 1. Tim Bunce and Andreas Koenig developed it further with
-their modifications to Test::Harness.
+their modifications to `Test::Harness`.
 
 ## Copyright
 

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -11,7 +11,7 @@ communities.
 
 This section will likely be removed prior to ratification.
 
-## GOALS OF THIS SPECIFICATION
+## Goals of This Specification
 
 * Document the observed behavior of widely used TAP implementations.
 * Add no features that are not already in wide usage across multiple
@@ -19,11 +19,11 @@ This section will likely be removed prior to ratification.
 * Explicitly allow what is already allowed, deny what is already denied.
 * Provide updated and clearer guidance for new TAP implementations.
 
-# NAME
+# Name
 
 TAP14 - The Test Anything Protocol v14
 
-## SYNOPSIS
+## Synopsis
 
 TAP, the Test Anything Protocol, is a simple text-based interface between
 testing modules a test harness. TAP started life as part of the test
@@ -36,7 +36,7 @@ _should_, _should not_, _recommended_, _may_, and _optional_ in this
 document are to be interpreted as described in [RFC
 2119](https://datatracker.ietf.org/doc/html/rfc2119).
 
-## TAP14 FORMAT
+## TAP14 Format
 
 TAP14's general grammar is:
 
@@ -45,10 +45,10 @@ TAPDocument := Version Plan Body | Version Body Plan
 Version     := "TAP version 14\n"
 Plan        := "1.." (Number) (" # " Reason)? "\n"
 Body        := (TestPoint | BailOut | Pragma | Comment | Anything | Empty)*
-TestPoint   := ("not ")? "ok" (" " Number)? ((" -")? (" " Description) )? (" " Directive)? "\n" (YamlBlock)?
+TestPoint   := ("not ")? "ok" (" " Number)? ((" -")? (" " Description) )? (" " Directive)? "\n" (YAMLBlock)?
 Directive   := "# " ("todo" | "skip") (" " Reason)?
-YamlBlock   := "  ---\n" (YamlLine)* "  ...\n"
-YamlLine    := "  " (Yaml)* "\n"
+YAMLBlock   := "  ---\n" (YAMLLine)* "  ...\n"
+YAMLLine    := "  " (YAML)* "\n"
 BailOut     := "Bail out!" (" " Reason)? "\n"
 Reason      := [^\n]+
 Pragma      := "pragma " [+-] PragmaKey "\n"
@@ -89,7 +89,7 @@ not ok 4 - Summarized correctly # TODO Not written yet
   ...
 ```
 
-## HARNESS BEHAVIOR
+## Harness Behavior
 
 In this document, the "harness" is any program analyzing TAP output.
 
@@ -126,7 +126,7 @@ interpreting TAP from a different sort of text stream, or for a purpose
 other than actually running tests.  For example, a Harness may be used to
 analyze the recorded output of past test runs and provide data about them.
 
-## TAP DOCUMENT STRUCTURE
+## Document Structure
 
 ### Version
 
@@ -341,7 +341,7 @@ defined semantics.
 
 Unrecognized directives _must_ be ignored, and treated as comments.
 
-##### TODO tests
+##### `TODO` tests
 
 If the directive starts with `# TODO`, the test is counted as a todo test,
 and the text after `TODO` is the explanation.
@@ -364,7 +364,7 @@ Harnesses _must not_ treat failing `TODO` test points as a test failure.
 Harneses _should_ report `TODO` test points found as a list of items
 needing work, if that is appropriate for their use case.
 
-##### SKIP tests
+##### `SKIP` tests
 
 If the directive starts with `# SKIP`, the test is counted as a skipped
 test, and the text after `SKIP` is the explanation.
@@ -501,7 +501,7 @@ The words "Bail out!" are case insensitive.
 
 ### Anything Else
 
-Any line that is not a valid version, plan, test point, yaml diagnostic,
+Any line that is not a valid version, plan, test point, YAML diagnostic,
 pragma, a blank line, or a bail out is invalid TAP.
 
 A Harness _may_ silently ignore invalid TAP lines, pass them through to its
@@ -607,7 +607,7 @@ TAP version 14
 1..0 # skip because English-to-French translator isn't installed
 ```
 
-## Got spare tuits?
+## Procrastination Considered `ok`
 
 The following example reports that four tests are run and the last two
 tests failed. However, because the failing tests are marked as things to do

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -356,7 +356,7 @@ Directives.  See "Escaping" below.
 ##### Backwards Compatibility and Parsing Notes
 
 For backwards compatibility with earlier incarnations of TAP, Harnesses
-_must_ accept additional non-whitespace characters following the the
+_must_ accept additional non-whitespace characters following the
 literal strings `"SKIP"` or `"TODO"`.  Everything after `(TODO|SKIP)\S*\s+`
 is the reason.  For example, this is supported, and shows a test with 2
 `skip` tests: one with no reason given, and the other with an explanation.

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -100,7 +100,7 @@ In a typical TAP implementation, tests are programs that ouput TAP data
 according to this specification.  The "test harness" reads TAP output from
 these programs, and handles it in some way.
 
-A harness that is collecting output from test programs _should_ read and
+A harness that is collecting output from a test program _should_ read and
 interpret TAP from the process's standard output, not standard error.
 (Handling of test standard error is implementation-specific.)
 

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -214,128 +214,122 @@ The core of TAP is the "Test Point". A test file prints one test point
 executed. There must be at least one test point in TAP output. Each test
 point comprises the following elements:
 
-- Test Status: `ok` or `not ok`
-
-    This tells whether the test point passed or failed. It must be at the
-    beginning of the line. `/^not ok/` indicates a failed test point.
-    `/^ok/` is a successful test point. This is the only mandatory part of
-    the line.
-
-    Note that unlike the Directives below, `ok` and `not ok` are
-    case-sensitive.
-
-- Test Point ID
-
-    TAP expects the ok or not ok to be followed by an integer Test Point
-    ID. If there is no number, the harness _must_ maintain its own counter
-    until the script supplies test numbers again.
-
-    For example, the following test output is acceptable:
-
-    ```tap
-    1..5
-    not ok
-    ok
-    not ok
-    ok
-    ok
-    ```
-
-    and is equivalent to:
-
-    ```tap
-    1..5
-    not ok 1
-    ok 2
-    not ok 3
-    ok 4
-    ok 5
-    ```
-
-    This test output is _not_ a successful test run:
-
-    ```tap
-    TAP version 13
-    1..6
-    not ok
-    ok
-    not ok
-    ok
-    ok
-    ```
-
-    Five tests are shown, but the plan indicated that there would be 6.
-    Furthermore, tests 1 and 3 are explicitly failing.  Perl's
-    `Test::Harness` will report:
-
-    ```
-    FAILED tests 1, 3, 6
-    Failed 3/6 tests, 50.00% okay
-    ```
-
-    Test Points _may_ be output in any order, but any Test Point ID
-    provided _must_ be within the range described by the Plan.
-
-    This is valid TAP and a successful test run:
-
-    ```tap
-    TAP version 14
-    1..3
-    ok 2
-    ok 3
-    ok 1
-    ```
-
-    This is not a successful test run. Even though there are 3 Test Points,
-    the Test Point ID 4 is outside the stated Plan range.
-
-    ```tap
-    TAP version 14
-    1..3
-    ok 2
-    ok 4
-    ok 1
-    ```
-
-- Description
-
-    Any text after the test number but before a `#` is the description of
-    the test point.
-
-    ```tap
-    ok 42 - this is the description of the test
-    ```
-
-    Descriptions _should_ be separated from the Test Point Status and Test
-    Point ID by the string `" - "`, in order to prevent confusing a numeric
-    description with a Test Point ID.  Harnesses _must_ treat Test Points
-    identically whether the description starts with `" - "` or not.
-
-    For example, these two test points _must_ be treated identically by a
-    Harness:
-
-    ```tap
-    ok 1 this is fine
-    ok 1 - this is fine
-    ```
-
-    Harnesses _should not_ consider a leading `" - "` to be a part of the
-    description reported to a user.
-
-- Directive
-
-    The test point may include a directive, following a `#` on the test
-    line.  There are currently two Directives allowed: `TODO` and `SKIP`.
-    These are discussed below.
-
-To summarize:
+In summary:
 
 - Test Status: `ok`/`not ok` (required)
 - Test number (recommended)
 - Description (recommended, prefixed by `" - "`)
 - Directive (only when necessary)
 
-#### Directives
+#### Test Status: `ok` or `not ok`
+
+This tells whether the test point passed or failed. It must be at the
+beginning of the line. `/^not ok/` indicates a failed test point.
+`/^ok/` is a successful test point. This is the only mandatory part of
+the line.
+
+Note that unlike the Directives below, `ok` and `not ok` are
+case-sensitive.
+
+#### Test Point ID
+
+TAP expects the ok or not ok to be followed by an integer Test Point
+ID. If there is no number, the harness _must_ maintain its own counter
+until the script supplies test numbers again.
+
+For example, the following test output is acceptable:
+
+```tap
+1..5
+not ok
+ok
+not ok
+ok
+ok
+```
+
+and is equivalent to:
+
+```tap
+1..5
+not ok 1
+ok 2
+not ok 3
+ok 4
+ok 5
+```
+
+This test output is _not_ a successful test run:
+
+```tap
+TAP version 13
+1..6
+not ok
+ok
+not ok
+ok
+ok
+```
+
+Five tests are shown, but the plan indicated that there would be 6.
+Furthermore, tests 1 and 3 are explicitly failing.  Perl's
+`Test::Harness` will report:
+
+```
+FAILED tests 1, 3, 6
+Failed 3/6 tests, 50.00% okay
+```
+
+Test Points _may_ be output in any order, but any Test Point ID
+provided _must_ be within the range described by the Plan.
+
+This is valid TAP and a successful test run:
+
+```tap
+TAP version 14
+1..3
+ok 2
+ok 3
+ok 1
+```
+
+This is not a successful test run. Even though there are 3 Test Points,
+the Test Point ID 4 is outside the stated Plan range.
+
+```tap
+TAP version 14
+1..3
+ok 2
+ok 4
+ok 1
+```
+
+#### Description
+
+Any text after the test number but before a `#` is the description of
+the test point.
+
+```tap
+ok 42 - this is the description of the test
+```
+
+Descriptions _should_ be separated from the Test Point Status and Test
+Point ID by the string `" - "`, in order to prevent confusing a numeric
+description with a Test Point ID.  Harnesses _must_ treat Test Points
+identically whether the description starts with `" - "` or not.
+
+For example, these two test points _must_ be treated identically by a
+Harness:
+
+```tap
+ok 1 this is fine
+ok 1 - this is fine
+```
+
+Harnesses _should not_ consider a leading `" - "` to be a part of the
+description reported to a user.
+
+#### Directive
 
 Directives are special notes that follow the first unescaped `#` on the
 Test Point line.  Only two are currently defined: `TODO` and `SKIP`.

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -304,6 +304,10 @@ ok 4
 ok 1
 ```
 
+Test Point IDs _should_ be unique within the TAP Document.  Harnesses _may_
+warn about repeated Test Point IDs or treat them as a test failure, but
+_must not_ treat a Test Point with a re-used ID as a non-TAP line.
+
 #### Description
 
 Any text after the test number but before a `#` is the description of

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -299,8 +299,16 @@ point comprises the following elements:
 
     Descriptions _should_ be separated from the Test Point Status and Test
     Point ID by the string `" - "`, in order to prevent confusing a numeric
-    description with a Test Point ID.  However, the `" - "` separator is
-    _optional_.
+    description with a Test Point ID.  Harnesses _must_ treat Test Points
+    identically whether the description starts with `" - "` or not.
+
+    For example, these two test points _must_ be treated identically by a
+    Harness:
+
+    ```tap
+    ok 1 this is fine
+    ok 1 - this is fine
+    ```
 
     Harnesses _should not_ consider a leading `" - "` to be a part of the
     description reported to a user.

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -778,18 +778,18 @@ useful in a variety of situations.  For example:
     1..2
     ```
 
-Subtests are designed with graceful fallback for TAP 13 harnesses in mind.
+Subtests are designed with graceful fallback for TAP13 harnesses in mind.
 
-Since TAP 13 specifies that non-TAP output _should_ be ignored or provided
+Since TAP13 specifies that non-TAP output _should_ be ignored or provided
 directly to the user, and indented Test Points and Plans are non-TAP
-according to TAP 13, only the terminating correlated test point will be
-interpreted by most TAP 13 Harnesses.  Thus, they will usually report the
+according to TAP13, only the terminating correlated test point will be
+interpreted by most TAP13 Harnesses.  Thus, they will usually report the
 overall subtest result correctly, even if they lack the details about the
 results of the subtest.
 
-Since several TAP 13 parsers in popular usage treat a repeated Version
+Since several TAP13 parsers in popular usage treat a repeated Version
 declaration as an error, even if the Version is indented, Subtests _should
-not_ include a Version, if TAP 13 Harness compatibility is desirable.
+not_ include a Version, if TAP13 Harness compatibility is desirable.
 
 ### Bare Subtests
 
@@ -910,8 +910,8 @@ Any Pragmas set in a Subtest affect _only_ the parsing of the Subtest.
 Harnesses _must not_ allow Pragmas set in Subtests to affect the behavior
 of the parser with respect to the parent TAP Document.
 
-For example, given a Harnesses where a `strict` Pragma will cause it to
-treat any non-TAP as an error:
+For example, given a Harness where a `strict` Pragma will cause it to treat
+any non-TAP as an error:
 
 ```tap
 TAP version 14
@@ -941,7 +941,7 @@ failure, because the `strict` Pragma setting at the parent level was false.
        block for a Test Point in a nested subtest would be indented 6
        spaces (4 + 2).  In a subtest nested within another subtest, YAML
        diagnostics would be indented 10 spaces (4 + 4 + 2).
-3. Subtests _should not_ emit a Version line, if compatibility with TAP 13
+3. Subtests _should not_ emit a Version line, if compatibility with TAP13
    Harnesses is desirable.
 4. The subtest is terminated by a single Test Point line in the parent TAP
    document, which follows the indented TAP Document.  This is the
@@ -949,7 +949,7 @@ failure, because the `strict` Pragma setting at the parent level was false.
     1. Producers _must_ communicate the intended status of the subtest
        (pass/fail/todo/skip/etc.) by assigning these semantics to the
        correlated Test Point.
-    2. Harneses _should_ treat the entire subtest as either a pass or fail
+    2. Harnesses _should_ treat the entire subtest as either a pass or fail
        based on the status of the correlated Test Point, but _may_ treat
        the subtest as a failure if they would consider the nested subtest
        TAP Document a test failure.
@@ -1147,7 +1147,7 @@ considerable input, encouragement, feedback, and suggestions from:
 Special thanks to [Jonathan Kingston](https://github.com/jonathanKingston)
 for his efforts to keep TAP flourishing and bring implementors together.
 
-The TAP 13 Specification was written by Andy Armstrong with help and
+The TAP13 Specification was written by Andy Armstrong with help and
 contributions from Pete Krawczyk, Paul Johnson, Ian Langworth and Nik
 Clayton, based on the original TAP documentation by Andy Lester, based on
 the original `Test::Harness` documentation by Michael Schwern.

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -495,10 +495,11 @@ were not tested, if that is appropriate for their use case.
 
 ### YAML Diagnostics
 
-If a Test Point is followed by a 2-space indented block beginning with
-the line `  ---` and ending with the line `  ...`, separated from the Test
+If a Test Point is followed by a 2-space indented block beginning with the
+line `  ---` and ending with the line `  ...`, separated from the Test
 Point only by comments or whitespace, then the block of lines between these
-markers will be interpreted as an inline YAML Diagnostic document.
+markers will be interpreted as an inline YAML Diagnostic document according
+to version 1.2 of the [YAML specification](https://yaml.org).
 
 The YAML encodes a data structure that provides information about the
 preceding Test Point.

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -43,18 +43,23 @@ TAP14's general grammar is:
 ```ebnf
 TAPDocument := Version Plan Body | Version Body Plan
 Version     := "TAP version 14\n"
-Plan        := (Number) ".." (Number) (" # " Reason)? "\n"
+Plan        := "1.." (Number) (" # " Reason)? "\n"
 Body        := (TestPoint | BailOut | Pragma | Comment | Anything | Empty)*
-TestPoint   := ("not ")? "ok" (" " Number)? ((" -")? (" " Description) )? "\n" (YamlBlock)?
+TestPoint   := ("not ")? "ok" (" " Number)? ((" -")? (" " Description) )? (" " Directive)? "\n" (YamlBlock)?
+Directive   := "# " ("todo" | "skip") (" " Reason)?
 YamlBlock   := "  ---\n" (YamlLine)* "  ...\n"
 YamlLine    := "  " (Yaml)* "\n"
-BailOut     := "Bail out!" (" " Reason)?
+BailOut     := "Bail out!" (" " Reason)? "\n"
+Reason      := [^\n]+
 Pragma      := "pragma " [+-] PragmaKey "\n"
 PragmaKey   := ([a-zA-Z0-9_-])+
-Comment     := (" ")* "#" [^\n]* "\n"
+Comment     := ^ (" ")* "#" [^\n]* "\n"
 Empty       := [\s\t]* "\n"
 Anything    := [^\n]+ "\n"
 ```
+
+(Note that the above is intended as a rough "pseudocode" guidance for
+humans.  It is not strict EBNF.)
 
 The Version is the line `TAP version 14`.
 

--- a/tap-version-14-specification.md
+++ b/tap-version-14-specification.md
@@ -329,7 +329,7 @@ To summarize:
 
 #### DIRECTIVES
 
-Directives are special notes that follow a # on the Test Point line. Only
+Directives are special notes that follow a `#` on the Test Point line. Only
 two are currently defined: `TODO` and `SKIP`. These two keywords are not
 case-sensitive.
 


### PR DESCRIPTION
The goal this time around will be to make small uncontroversial changes, which can step us into paving the paths laid by node-tap, Test::More, tappy, and many others over the years.  There will be no innovation here, just cataloging what exists.

Goals:

* No changes will be accepted UNLESS they are already widely adopted by multiple implementations representing a majority of the TAP userbase.

* No changes will be blocked IF they are already widely adopted by multiple implementations representing a majority of the TAP userbase.

* Specification should remove as much ambiguity as possible, while maintaining backwards compatibility with existing TAP providers and consumers.

Features/Changes Anticipated:

* Change the version from 13 to 14 (of course)
* Require that yaml diagnostic blocks be actual yaml, stipulate that they are to be indented 2 spaces.
* Specify child tests (both indented and {}-wrapped buffered), indented 4 spaces.
* Specify pragmas (at least, define the syntax, even if the specific keys are left up to implementations)
* Clean up and clarify ambiguous language.